### PR TITLE
feat: 베이스 라인 구현 (메뉴 평점 기반 추천)

### DIFF
--- a/app/api/predict.py
+++ b/app/api/predict.py
@@ -1,1 +1,14 @@
-# GET /models/predict: 사용자 입력(예: user_id)을 받아 추천 결과 반환
+from fastapi import APIRouter
+from app.schemas.predict import MenuComparisonRequest, MenuRecommendationResponse
+from app.models.recommender import recommend_menu_by_score
+
+router = APIRouter()
+
+@router.post("/predict", response_model=MenuRecommendationResponse)
+def recommend_menu(request: MenuComparisonRequest):
+    recommended_id, score_a, score_b = recommend_menu_by_score(request.menu_id_a, request.menu_id_b)
+    return MenuRecommendationResponse(
+        recommended_menu_id=recommended_id,
+        menu_a_score=round(score_a, 2),
+        menu_b_score=round(score_b, 2)
+    )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,6 +2,11 @@ from pydantic_settings import BaseSettings
 from functools import lru_cache
 from typing import Optional, Set
 from pathlib import Path
+import os
+from dotenv import load_dotenv
+
+# 환경변수 로딩
+load_dotenv(override=True)
 
 class Settings(BaseSettings):
     # API 설정
@@ -12,6 +17,13 @@ class Settings(BaseSettings):
     HOST: str = "0.0.0.0"
     PORT: int = 8000
     DEBUG: bool = True
+    
+    # MySQL 설정
+    MYSQL_HOST: str
+    MYSQL_PORT: int
+    MYSQL_USER: str
+    MYSQL_PASSWORD: str
+    MYSQL_DB: str
     
     # 파일 업로드 설정
     UPLOAD_DIR: Path = Path("uploads")
@@ -34,6 +46,7 @@ class Settings(BaseSettings):
     class Config:
         env_file = ".env"
         case_sensitive = True
+        env_file_encoding = 'utf-8'
 
 @lru_cache()
 def get_settings() -> Settings:
@@ -44,3 +57,12 @@ def get_settings() -> Settings:
 
 # 설정 인스턴스 생성
 settings = get_settings()
+
+# DB 설정
+DB_CONFIG = {
+    "host": settings.MYSQL_HOST,
+    "port": settings.MYSQL_PORT,
+    "user": settings.MYSQL_USER,
+    "password": settings.MYSQL_PASSWORD,
+    "database": settings.MYSQL_DB
+}

--- a/app/models/recommender.py
+++ b/app/models/recommender.py
@@ -1,0 +1,33 @@
+import pymysql
+from typing import Tuple
+from app.core.config import DB_CONFIG
+
+def get_db_conn():
+    return pymysql.connect(
+        host=DB_CONFIG["host"],
+        port=DB_CONFIG["port"],
+        user=DB_CONFIG["user"],
+        password=DB_CONFIG["password"],
+        database=DB_CONFIG["database"],
+        cursorclass=pymysql.cursors.DictCursor
+    )
+
+def get_menu_average_score(conn, menu_id: int) -> float:
+    query = """
+    SELECT AVG(fr.food_score) AS avg_score
+    FROM menu_food mf
+    JOIN food_review fr ON mf.food_id = fr.food_id
+    WHERE mf.menu_id = %s
+    """
+    with conn.cursor() as cur:
+        cur.execute(query, (menu_id,))
+        result = cur.fetchone()
+        return result["avg_score"] or 0.0
+
+def recommend_menu_by_score(menu_a: int, menu_b: int) -> Tuple[int, float, float]:
+    conn = get_db_conn()
+    score_a = get_menu_average_score(conn, menu_a)
+    score_b = get_menu_average_score(conn, menu_b)
+    conn.close()
+    recommended = menu_a if score_a >= score_b else menu_b
+    return recommended, score_a, score_b

--- a/app/schemas/predict.py
+++ b/app/schemas/predict.py
@@ -1,9 +1,10 @@
-# from pydantic import BaseModel
-# from typing import List
+from pydantic import BaseModel
 
-# class PredictRequest(BaseModel):
-#     user_id: int
+class MenuComparisonRequest(BaseModel):
+    menu_id_a: int
+    menu_id_b: int
 
-# class PredictResponse(BaseModel):
-#     user_id: int
-#     recommendations: List[str]
+class MenuRecommendationResponse(BaseModel):
+    recommended_menu_id: int
+    menu_a_score: float
+    menu_b_score: float

--- a/main.py
+++ b/main.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI
 from app.api import ocr
+from app.api import predict
 
-app = FastAPI(title="OCR API")
+app = FastAPI(title="MLOps API")
 
 # 라우터 등록
 app.include_router(ocr.router, prefix="/api/v1", tags=["ocr"])
+app.include_router(predict.router, prefix="/api/v1", tags=["predict"])
 
 if __name__ == "__main__":
     import uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic-settings==2.0.3
 pandas==2.1.3
 requests==2.31.0
 python-dotenv==1.0.0
+pymysql==1.1.0


### PR DESCRIPTION
## 📄 작업 내용
- **FastAPI 기반 메뉴 추천 API (1번) 구현**
  - 메뉴 A, B의 `menu_id`를 입력받아 구성된 음식들의 평균 평점을 비교하여 더 나은 메뉴를 추천하는 API 추가
  - 단일 SQL 쿼리 기반 평점 계산 로직으로 빠르게 응답
  - `menu_food` + `food_review`를 JOIN하여 평균 평점 계산
  - 추천 메뉴 ID(`recommended_menu_id`) 및 각 메뉴의 평균 점수(`menu_a_score`, `menu_b_score`)를 응답으로 반환

- **MySQL 기반 DB 연동 및 환경설정**
  - `.env` 파일에서 DB 접속 정보를 관리하고, `core/config.py`에서 불러오는 구조로 설정 분리
  - `pymysql` 기반 DB 연결 함수 `get_db_conn()` 구현

- **Pydantic 요청/응답 모델 정의 (`schemas/predict.py`)**
  - `MenuComparisonRequest`: 메뉴 A/B의 ID 입력
  - `MenuRecommendationResponse`: 추천된 메뉴 ID와 각 메뉴 평균 점수 포함

- **FastAPI 라우터 등록 (`api/predict.py`)**
  - `/api/recommend` 경로에 POST 요청으로 추천 기능 제공
  - Swagger UI (`/docs`)에서 테스트 가능

---

## 📎 Issue 번호
#3